### PR TITLE
Re-export MCapstone module and include WASM instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,13 @@ To build the Capstone.js library, clone the *master* branch of this repository, 
 3. Install the development dependencies with: `npm install`.
 
 4. Finally, build the source with: `grunt build`.
+
+Note: To use WebAssembly, change `WASM=0` to `WASM=1` in `build.py`.
+
+It will automatically load the `.wasm` binary, but you should wait for it to load:
+
+```javascript
+cs.MCapstone.then(() => {
+    // ... initialize and use Capstone here ....
+});
+```

--- a/build.py
+++ b/build.py
@@ -9,6 +9,8 @@ import re
 import sys
 
 EXPORTED_FUNCTIONS = [
+    '_malloc',
+    '_free',
     '_cs_open',
     '_cs_disasm',
     '_cs_free',

--- a/build.py
+++ b/build.py
@@ -3,6 +3,7 @@
 # INFORMATION:
 # This scripts compiles the original Capstone framework to JavaScript
 
+from __future__ import print_function
 import os
 import re
 import sys
@@ -85,7 +86,7 @@ def compileCapstone(targets):
         cmd += ' -G \"Unix Makefiles\"'
     cmd += ' capstone/CMakeLists.txt'
     if os.system(cmd) != 0:
-        print "CMake errored"
+        print("CMake errored")
         sys.exit(1)
 
     # MinGW (Windows) or Make (Linux/Unix)
@@ -95,7 +96,7 @@ def compileCapstone(targets):
     if os.name == 'posix':
         make = 'make'
     if os.system(make) != 0:
-        print "Make errored"
+        print("Make errored")
         sys.exit(1)
     os.chdir('..')
 
@@ -118,7 +119,7 @@ def compileCapstone(targets):
     else:
         cmd += ' -o src/libcapstone.out.js'
     if os.system(cmd) != 0:
-        print "Emscripten errored"
+        print("Emscripten errored")
         sys.exit(1)
 
 
@@ -132,5 +133,5 @@ if __name__ == "__main__":
         generateConstants()
         compileCapstone(targets)
     else:
-        print "Your operating system is not supported by this script:"
-        print "Please, use Emscripten to compile Capstone manually to src/libcapstone.out.js"
+        print("Your operating system is not supported by this script:")
+        print("Please, use Emscripten to compile Capstone manually to src/libcapstone.out.js")

--- a/build.py
+++ b/build.py
@@ -62,10 +62,10 @@ def generateConstants():
 
 def compileCapstone(targets):
     # Clean CMake cache
-    if os.name == 'nt':
-        os.system('del capstone\\CMakeCache.txt')
-    if os.name == 'posix':
-        os.system('rm capstone/CMakeCache.txt')
+    try:
+        os.remove('capstone/CMakeCache.txt')
+    except OSError:
+        pass
 
     # CMake
     cmd = 'cmake'
@@ -84,14 +84,19 @@ def compileCapstone(targets):
     if os.name == 'posix':
         cmd += ' -G \"Unix Makefiles\"'
     cmd += ' capstone/CMakeLists.txt'
-    os.system(cmd)
+    if os.system(cmd) != 0:
+        print "CMake errored"
+        sys.exit(1)
 
     # MinGW (Windows) or Make (Linux/Unix)
     os.chdir('capstone')
     if os.name == 'nt':
-        os.system('mingw32-make')
+        make = 'mingw32-make'
     if os.name == 'posix':
-        os.system('make')
+        make = 'make'
+    if os.system(make) != 0:
+        print "Make errored"
+        sys.exit(1)
     os.chdir('..')
 
     # Compile static library to JavaScript
@@ -112,7 +117,9 @@ def compileCapstone(targets):
         cmd += ' -o src/libcapstone-%s.out.js' % '-'.join(targets).lower()
     else:
         cmd += ' -o src/libcapstone.out.js'
-    os.system(cmd)
+    if os.system(cmd) != 0:
+        print "Emscripten errored"
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/capstone-wrapper.js
+++ b/src/capstone-wrapper.js
@@ -4,9 +4,11 @@
  */
 
 // Emscripten demodularize
-var MCapstone = new MCapstone();
+MCapstone = MCapstone();
 
 var cs = {
+    MCapstone: MCapstone,
+    
     // Return codes
     ERR_OK: 0,         // No error: everything was fine
     ERR_MEM: 1,        // Out-Of-Memory error: cs_open(), cs_disasm(), cs_disasm_iter()


### PR DESCRIPTION
Also ensures `_malloc` and `_free` are exported, so that optimizations don't omit them from the build.