### PR TITLE
Fix error "cannot import module" for npm installations

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "https://github.com/AlexAltea/capstone.js.git"
   },
+  "main": "./dist/capstone.min.js",
   "dependencies": {},
   "devDependencies": {
     "bower": "^1.8.8",


### PR DESCRIPTION
This fixes #19 by adding the `capstone.min.js` file as the project's entry point in the `package.json`.